### PR TITLE
feat: fix issue of failure when multiple deposit+withdraw

### DIFF
--- a/circuit/src/lib.rs
+++ b/circuit/src/lib.rs
@@ -48,7 +48,7 @@ pub fn to_bits(num: &[u8]) -> Vec<bool> {
 pub fn num_to_bits_vec(num: u64) -> Vec<bool> {
     let bits = to_bits(&num.to_le_bytes());
 
-    bits[..u64::BITS as usize].to_vec()
+    bits[..u32::BITS as usize].to_vec()
 }
 
 fn next_index(i: u64) -> u64 {

--- a/circuit/src/merkle.rs
+++ b/circuit/src/merkle.rs
@@ -3,20 +3,6 @@ use serde::Serialize;
 use sha3::{Digest, Keccak256};
 use std::{collections::HashMap, marker::PhantomData};
 
-pub fn to_bits(num: &[u8]) -> Vec<bool> {
-    let len = num.len() * 8;
-    let mut bits = Vec::new();
-    for i in 0..len {
-        let bit = num[i / 8] & (1 << (i % 8)) != 0;
-        bits.push(bit);
-    }
-    bits
-}
-
-pub fn num_to_bits(num: u64) -> Vec<bool> {
-    to_bits(num.to_be_bytes().as_ref())
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct Path {
     index: u64,
@@ -26,7 +12,7 @@ pub struct Path {
 
 impl Path {
     pub fn verify_against(&self, root: Hash) -> bool {
-        let sides = num_to_bits(self.index);
+        let sides = num_to_bits_vec(self.index);
         let mut next = self.leaf.clone();
         for (n, left) in self
             .neighbours

--- a/circuit/src/merkle.rs
+++ b/circuit/src/merkle.rs
@@ -11,7 +11,7 @@ pub struct Path {
 }
 
 impl Path {
-    pub fn verify_against(&self, root: Hash) -> bool {
+    pub fn construct_root(&self) -> Hash {
         let sides = num_to_bits_vec(self.index);
         let mut next = self.leaf.clone();
         for (n, left) in self
@@ -26,7 +26,7 @@ impl Path {
             };
             next = new_next;
         }
-        root == next
+        next
     }
 }
 

--- a/ui/src/util/mod.rs
+++ b/ui/src/util/mod.rs
@@ -18,23 +18,15 @@ impl UnShieldedAccountState {
 pub struct ShieldedAccountState {
     pub id: usize,
     pub address: String,
-    pub deposit_amount: u64,
     pub withdraw_success: bool,
     pub nullifier: String,
 }
 
 impl ShieldedAccountState {
-    pub fn new(
-        id: usize,
-        address: String,
-        deposit_amount: u64,
-        withdraw_success: bool,
-        nullifier: String,
-    ) -> Self {
+    pub fn new(id: usize, address: String, withdraw_success: bool, nullifier: String) -> Self {
         Self {
             id,
             address,
-            deposit_amount,
             withdraw_success,
             nullifier,
         }
@@ -45,7 +37,7 @@ impl ShieldedAccountState {
 pub struct UnShieldAccountProps {
     pub address: String,
     pub balance: u64,
-    pub deposit_clicked: Callback<(String, u64)>,
+    pub deposit_clicked: Callback<String>,
 }
 
 #[derive(Properties, PartialEq)]
@@ -66,6 +58,11 @@ pub struct DepositParams {
 #[derive(Serialize)]
 pub struct WithdrawParams {
     pub(crate) nullifier: Hash,
+}
+
+#[derive(Serialize)]
+pub struct GetBalanceParams {
+    pub(crate) account: u64,
 }
 
 impl WithdrawParams {


### PR DESCRIPTION
## Changes
- correct the `circuits::num_to_bits_vec` util 
- remove the unnecessary `num_to_bits` util

## What to fix
Currently, the multiple deposit+withdraw fails.
The reason is that `Note` includes the old `merkle_path`, and the `merkle_path` fails to match the latest tree `root`.
For example, let us assume I deposit 2 times.
I get the 2 nullifiers, which means the `NOTES` includes 2 notes matching the nullifiers.
First deposit note includes the merkle path corresponding to S0 state/root. (when the merkle tree has 1st insert)
Second deposit note includes the merkle path corresponding to S1 state/root. (when the merkle tree has 2nd insert)
S0 root and S1 root are different.
When I try to withdraw with 1st nullifier(note/merkle path), it tries to verify the merkle path against latest tree root = S1 state/root.
Hence, it fails to verify against S1 root, since 1st merkle path matches with S0 root.
